### PR TITLE
fix: Embed entrypoint script into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,10 +61,13 @@ RUN echo '#!/bin/bash' > /usr/local/bin/init.sh && \
 # Make the script executable
 RUN chmod +x /usr/local/bin/init.sh
 
-# Copy and set up the entrypoint
-COPY entrypoint.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/entrypoint.sh
-ENTRYPOINT ["entrypoint.sh"]
+# Create and set up the entrypoint script
+RUN echo '#!/bin/bash' > /usr/local/bin/entrypoint.sh && \
+    echo 'echo "Starting MySQL service..."' >> /usr/local/bin/entrypoint.sh && \
+    echo 'service mysql start' >> /usr/local/bin/entrypoint.sh && \
+    echo 'exec "$@"' >> /usr/local/bin/entrypoint.sh && \
+    chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # Set the default command to an interactive shell
 CMD ["/bin/bash"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Start MySQL service in the background
-echo "Starting MySQL service..."
-service mysql start
-
-# Execute the command passed to this script (e.g., /bin/bash)
-exec "$@"


### PR DESCRIPTION
This commit resolves an issue where the Docker build would fail because the `entrypoint.sh` script was missing from the build context. The user's setup instructions guide them to download only the `Dockerfile`, so any other required files must be created by the Dockerfile itself.

The `entrypoint.sh` file has been removed from the repository, and the `Dockerfile` has been updated to create it on-the-fly using a `RUN` command with `echo`. This makes the `Dockerfile` fully self-contained and aligns with the project's goal of a simplified, single-file setup process.