### PR TITLE
Fix git push authentication prompt by adding GitHub CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH="/workspace/bin:${PATH}"
 
 # Install dependencies
-RUN apt-get update && apt-get install -y git curl ca-certificates wget rsync mysql-server mysql-client
+RUN apt-get update && apt-get install -y git curl ca-certificates wget rsync mysql-server mysql-client lsb-release
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get install gh -y
 
 # Create the init.sh script
 RUN echo '#!/bin/bash' > /usr/local/bin/init.sh && \

--- a/README.md
+++ b/README.md
@@ -81,7 +81,32 @@ Run the exact same `docker run` command a second time to begin your development 
   docker run -it --rm -v "%cd%":/workspace egi-330-env
   ```
 
-You are now inside your development environment, which has all the necessary tools and your project files. You can push the initial commit by running:
+You are now inside your development environment, which has all the necessary tools and your project files.
+
+### Step 7: Authenticate with GitHub
+
+Before you can push your code to your GitHub repository, you need to authenticate. We've included the GitHub CLI to make this easy.
+
+Inside the container, run the following command:
+```sh
+gh auth login
+```
+
+This command will ask you a few questions:
+- **What account do you want to log into?** Select `GitHub.com`.
+- **What is your preferred protocol for Git operations?** Select `HTTPS`.
+- **Authenticate Git with your GitHub credentials?** Select `Y` (Yes).
+- **How would you like to authenticate?** Select `Login with a web browser`.
+
+It will then give you a one-time code and ask you to open a URL in your browser. Copy the code, then open the link in your web browser on your main computer (not in the container) and paste the code to authorize the CLI.
+
+After you've authenticated, you can proceed to the final step.
+
+### Step 8: Push Your Initial Commit
+
+Now that you are authenticated, you can push your initial commit to your remote repository on GitHub.
+
+Run the following command:
 ```sh
 git push -u origin main
 ```


### PR DESCRIPTION
The user was being prompted for a username and password when running `git push` over HTTPS from within the provided Docker container.

This change resolves the issue by installing the GitHub CLI (`gh`) into the Docker image. The `README.md` has been updated with instructions for the user to perform a one-time authentication using `gh auth login`.

This allows `git` to use the stored credentials from `gh` for HTTPS operations, providing a seamless push/pull experience without repeated login prompts.